### PR TITLE
Ship javascript, not binaries

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "typecheck": "tsc --noEmit",
     "format": "prettier --write \"**/*.{ts,js,json,md}\"",
     "format:check": "prettier --check \"**/*.{ts,js,json,md}\"",
-    "prebuild": "bun build src/index.ts --target node --outfile dist/hume.js",
+    "prebuild": "bun build src/index.ts --target node --outfile dist/index.js",
     "prepublishOnly": "npm run prebuild"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@humeai/cli",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "module": "index.ts",
   "type": "module",
   "description": "CLI for Hume.ai's OCTAVE expressive TTS API",
@@ -18,12 +18,11 @@
     "typecheck": "tsc --noEmit",
     "format": "prettier --write \"**/*.{ts,js,json,md}\"",
     "format:check": "prettier --check \"**/*.{ts,js,json,md}\"",
-    "prebuild": "bun build src/index.ts --compile --outfile dist/hume",
+    "prebuild": "bun build src/index.ts --target node --outfile dist/hume.js",
     "prepublishOnly": "npm run prebuild"
   },
   "dependencies": {
     "@clack/prompts": "^0.10.0",
-    "bun": "^1.2.2",
     "clipanion": "^4.0.0-rc.4",
     "debug": "^4.4.0",
     "hume": "^0.10.3",
@@ -31,9 +30,9 @@
     "typanion": "^3.14.0"
   },
   "files": [
-    "dist/hume"
+    "dist/index.js"
   ],
   "bin": {
-    "hume": "dist/hume"
+    "hume": "dist/index.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "typecheck": "tsc --noEmit",
     "format": "prettier --write \"**/*.{ts,js,json,md}\"",
     "format:check": "prettier --check \"**/*.{ts,js,json,md}\"",
-    "prebuild": "bun build src/index.ts --target node --outfile dist/index.js",
+    "prebuild": "bun build src/index.ts --target node --outfile dist/index.js && chmod +x dist/index.js",
     "prepublishOnly": "npm run prebuild"
   },
   "dependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 import {
   Cli,
   Command as ClipanionBaseCommand,

--- a/src/play_audio.ts
+++ b/src/play_audio.ts
@@ -1,4 +1,5 @@
 import { debug } from './common';
+import {spawnSync, spawn} from 'child_process';
 
 type Command = {
   cmd: string;
@@ -52,7 +53,7 @@ const findDefaultAudioPlayer_ = (): Command | null => {
   for (const player of commonPlayers) {
     const checkCmd = isWindows ? 'where' : 'which';
     try {
-      Bun.spawnSync([checkCmd, player.cmd]);
+      spawnSync(checkCmd, [player.cmd]);
       return player; // found!
     } catch {}
   }
@@ -62,18 +63,31 @@ const findDefaultAudioPlayer_ = (): Command | null => {
 
 export const playAudioFile = async (
   path: string,
-  customCommand: string | null
-): Promise<unknown> => {
+  customCommand: string | null,
+) => {
   const command = ensureAudioPlayer(
     customCommand ? parseCustomCommand(customCommand) : findDefaultAudioPlayer()
   );
   const isWindows = process.platform === 'win32';
   const sanitizedPath = isWindows ? path.replace(/\\/g, '\\\\') : path;
-
-  return Bun.spawn([command.cmd, ...command.argsWithPath(sanitizedPath)], {
-    stdout: 'ignore',
-    stderr: 'ignore',
-  }).exited;
+  
+  return new Promise<void>((resolve, reject) => {
+    const process = spawn(command.cmd, [...command.argsWithPath(sanitizedPath)], {
+      stdio: ['ignore', 'ignore', 'ignore']
+    });
+    
+    process.on('close', (code: number) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(new Error(`Process exited with code ${code}`));
+      }
+    });
+    
+    process.on('error', (err: any) => {
+      reject(err);
+    });
+  });
 };
 
 export const parseCustomCommand = (command: string): Command => {
@@ -114,17 +128,30 @@ export const withStdinAudioPlayer = async (
   const command = ensureStdinSupport(
     ensureAudioPlayer(customCommand ? parseCustomCommand(customCommand) : findDefaultAudioPlayer())
   );
-
   debug([command.cmd, command.argsWithStdin]);
-  const proc = Bun.spawn([command.cmd, ...command.argsWithStdin], {
-    stdout: 'ignore',
-    stderr: 'ignore',
-    stdin: 'pipe',
+  
+  const { spawn } = require('child_process');
+  const proc = spawn(command.cmd, [...command.argsWithStdin], {
+    stdio: ['pipe', 'ignore', 'ignore']
   });
-
-  await f((audioBuffer: Buffer) => {
+  
+  await f((audioBuffer) => {
     proc.stdin.write(audioBuffer);
   });
+  
   proc.stdin.end();
-  await proc.exited;
+  
+  return new Promise((resolve, reject) => {
+    proc.on('close', (code: number) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(new Error(`Process exited with code ${code}`));
+      }
+    });
+    
+    proc.on('error', (err: any) => {
+      reject(err);
+    });
+  });
 };

--- a/src/play_audio.ts
+++ b/src/play_audio.ts
@@ -1,5 +1,5 @@
 import { debug } from './common';
-import {spawnSync, spawn} from 'child_process';
+import { spawnSync, spawn } from 'child_process';
 
 type Command = {
   cmd: string;
@@ -61,21 +61,18 @@ const findDefaultAudioPlayer_ = (): Command | null => {
   return null;
 };
 
-export const playAudioFile = async (
-  path: string,
-  customCommand: string | null,
-) => {
+export const playAudioFile = async (path: string, customCommand: string | null) => {
   const command = ensureAudioPlayer(
     customCommand ? parseCustomCommand(customCommand) : findDefaultAudioPlayer()
   );
   const isWindows = process.platform === 'win32';
   const sanitizedPath = isWindows ? path.replace(/\\/g, '\\\\') : path;
-  
+
   return new Promise<void>((resolve, reject) => {
     const process = spawn(command.cmd, [...command.argsWithPath(sanitizedPath)], {
-      stdio: ['ignore', 'ignore', 'ignore']
+      stdio: ['ignore', 'ignore', 'ignore'],
     });
-    
+
     process.on('close', (code: number) => {
       if (code === 0) {
         resolve();
@@ -83,7 +80,7 @@ export const playAudioFile = async (
         reject(new Error(`Process exited with code ${code}`));
       }
     });
-    
+
     process.on('error', (err: any) => {
       reject(err);
     });
@@ -129,18 +126,18 @@ export const withStdinAudioPlayer = async (
     ensureAudioPlayer(customCommand ? parseCustomCommand(customCommand) : findDefaultAudioPlayer())
   );
   debug([command.cmd, command.argsWithStdin]);
-  
+
   const { spawn } = require('child_process');
   const proc = spawn(command.cmd, [...command.argsWithStdin], {
-    stdio: ['pipe', 'ignore', 'ignore']
+    stdio: ['pipe', 'ignore', 'ignore'],
   });
-  
+
   await f((audioBuffer) => {
     proc.stdin.write(audioBuffer);
   });
-  
+
   proc.stdin.end();
-  
+
   return new Promise((resolve, reject) => {
     proc.on('close', (code: number) => {
       if (code === 0) {
@@ -149,7 +146,7 @@ export const withStdinAudioPlayer = async (
         reject(new Error(`Process exited with code ${code}`));
       }
     });
-    
+
     proc.on('error', (err: any) => {
       reject(err);
     });


### PR DESCRIPTION
1. Stop using commands from Bun's standard library -- use the nodejs standard library instead.
2. Don't use bun to compile a standalone binary. Instead, put `#!/usr/bin/env node` at the top of index.ts and ship an index.js with the bundled Javascript for the entire CLI.

Downside of this: bun's startup time is faster so now the CLI will boot up a little slower when the user types a command.
Upside of this: we are essentially opting out of handling platform cross-compatibility ourselves, all we now rely upon is the user having a supported `node` binary somewhere on their system (which is pretty likely if they installed us via `npm install @humeai/cli`)

Tested via
`npm run prebuild && dist/index.js tts "Hello"` on both Linux and Mac.