### PR TITLE
Add --request-body and --curl flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ $ hume tts <text>
 --trailing-silence #0 Seconds of silence to add at the end (0.0-5.0, default is 0.35)
 --streaming Use streaming mode for TTS generation (default: true)
 --instant-mode Enable ultra-low latency mode for significantly faster generation (requires streaming=true, a voice, and incurs 10% higher cost)
+--curl Generate curl command instead of making the API request
 
 ━━━ Details ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
@@ -109,6 +110,9 @@ $ hume tts "Hello world" -v narrator --instant-mode
 
 Setting instant mode in your config (always enable)
 $ hume config set tts.instantMode true
+
+Generating curl command instead of making API request
+$ hume tts "Hello world" -v narrator --curl
 
 ## Voice Management
 

--- a/src/common.ts
+++ b/src/common.ts
@@ -160,8 +160,8 @@ export const formatApiKeyForCurl = (provenance: ApiKeyProvenance): string => {
     case 'env':
       return '$HUME_API_KEY';
     case 'global':
-      return '$(hume config show | jq \'.apiKey\')';
+      return "$(hume config show | jq '.apiKey')";
     case 'session':
-      return '$(hume session show | jq \'.apiKey\')';
+      return "$(hume session show | jq '.apiKey')";
   }
 };

--- a/src/common.ts
+++ b/src/common.ts
@@ -126,3 +126,42 @@ export const getHumeClient = (opts: { apiKey: string; baseUrl?: string }) => {
     environment: opts.baseUrl ?? 'https://api.hume.ai',
   });
 };
+
+export type ApiKeyProvenance = {
+  source: 'flag' | 'env' | 'global' | 'session';
+  value: string;
+};
+
+export const getApiKeyProvenance = (
+  opts: CommonOpts,
+  globalConfig: ConfigData,
+  session: ConfigData,
+  env: typeof process.env
+): ApiKeyProvenance | null => {
+  if (opts.apiKey) {
+    return { source: 'flag', value: opts.apiKey };
+  }
+  if (env.HUME_API_KEY) {
+    return { source: 'env', value: env.HUME_API_KEY };
+  }
+  if (session.apiKey) {
+    return { source: 'session', value: session.apiKey };
+  }
+  if (globalConfig.apiKey) {
+    return { source: 'global', value: globalConfig.apiKey };
+  }
+  return null;
+};
+
+export const formatApiKeyForCurl = (provenance: ApiKeyProvenance): string => {
+  switch (provenance.source) {
+    case 'flag':
+      return provenance.value;
+    case 'env':
+      return '$HUME_API_KEY';
+    case 'global':
+      return '$(hume config show | jq \'.apiKey\')';
+    case 'session':
+      return '$(hume session show | jq \'.apiKey\')';
+  }
+};

--- a/src/config.ts
+++ b/src/config.ts
@@ -34,6 +34,7 @@ export type ConfigData = {
     trailingSilence?: number;
     streaming?: boolean;
     instantMode?: boolean;
+    modelVersion?: '1' | '2';
   };
   json?: boolean;
   pretty?: boolean;
@@ -56,6 +57,7 @@ export const configValidators = {
   'tts.trailingSilence': t.cascade(t.isNumber(), t.isInInclusiveRange(0.0, 5.0)),
   'tts.streaming': t.isBoolean(),
   'tts.instantMode': t.isBoolean(),
+  'tts.modelVersion': t.isEnum(['1', '2'] as const),
   json: t.isBoolean(),
   pretty: t.isBoolean(),
   apiKey: t.isString(),

--- a/src/e2e.test.ts
+++ b/src/e2e.test.ts
@@ -895,4 +895,72 @@ describe('CLI End-to-End Tests', () => {
     // since the error format might vary
     expect(result.stderr.length).toBeGreaterThan(0);
   });
+
+  test('Curl option generates curl command', async () => {
+    const result = await testEnv.runCliTtsCommand(
+      ['Hello world', '--description', 'A friendly voice', '--curl'],
+      { env: DEFAULT_ENV }
+    );
+
+    logFailureDetails(result);
+
+    expect(result.exitCode).toBe(0);
+
+    // Should contain curl command output
+    expect(result.stdout).toContain('curl "');
+    expect(result.stdout).toContain('X-Hume-Api-Key: $HUME_API_KEY');
+    expect(result.stdout).toContain('--json');
+
+    // Should not make any actual API requests when using --curl
+    const ttsRequests = testEnv.getTtsRequests();
+    expect(ttsRequests.length).toBe(0);
+  });
+
+  test('Curl option with custom base URL', async () => {
+    const customBaseUrl = 'https://custom.api.hume.ai';
+
+    const result = await testEnv.runCliCommand(
+      [
+        'tts',
+        'Hello world',
+        '--description',
+        'A friendly voice',
+        '--curl',
+        '--base-url',
+        customBaseUrl,
+      ],
+      { env: DEFAULT_ENV }
+    );
+
+    logFailureDetails(result);
+
+    expect(result.exitCode).toBe(0);
+
+    // Should contain curl command with custom base URL
+    expect(result.stdout).toContain(`curl "${customBaseUrl}/v0/tts/stream/json"`);
+
+    // Should not make any actual API requests when using --curl
+    const ttsRequests = testEnv.getTtsRequests();
+    expect(ttsRequests.length).toBe(0);
+  });
+
+  test('Curl option with non-streaming mode', async () => {
+    const result = await testEnv.runCliCommand(
+      ['tts', 'Hello world', '--description', 'A friendly voice', '--curl', '--no-streaming'],
+      { env: DEFAULT_ENV }
+    );
+
+    logFailureDetails(result);
+
+    expect(result.exitCode).toBe(0);
+
+    // Should contain curl command with non-streaming endpoint
+    expect(result.stdout).toContain('curl "');
+    expect(result.stdout).toContain('/v0/tts"');
+    expect(result.stdout).not.toContain('/stream/json');
+
+    // Should not make any actual API requests when using --curl
+    const ttsRequests = testEnv.getTtsRequests();
+    expect(ttsRequests.length).toBe(0);
+  });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,7 @@ const usageDescriptions = {
   'tts.instantMode':
     'Enable ultra-low latency mode for significantly faster generation (requires streaming=true, a voice, and incurs 10% higher cost)',
   'tts.modelVersion': "Either '1' for Octave 1 or '2' for Octave 2.",
+  'tts.curl': 'Generate curl command instead of making the API request',
   apiKey: 'Override the default API key',
   json: 'Output in JSON format',
   pretty: 'Output in human-readable format',
@@ -465,6 +466,10 @@ class TtsCommand extends Command {
   requestJson = Option.String('--request-json', {
     description:
       'Override the request body with a hardcoded JSON string instead of generating it from options',
+  });
+
+  curl = Option.Boolean('--curl', {
+    description: usageDescriptions['tts.curl'],
   });
 
   async execute() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -462,7 +462,7 @@ class TtsCommand extends Command {
     validator: t.isEnum(['1', '2'] as const),
   });
 
-  requestBody = Option.String('--request-body', {
+  requestJson = Option.String('--request-json', {
     description:
       'Override the request body with a hardcoded JSON string instead of generating it from options',
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -374,7 +374,7 @@ class TtsCommand extends Command {
     }
   );
 
-  text = Option.String({ required: true, name: 'text' });
+  text = Option.String({ required: false, name: 'text' });
   description = Option.String('-d,--description', {
     description: usageDescriptions['tts.description'],
   });
@@ -460,6 +460,11 @@ class TtsCommand extends Command {
   modelVersion = Option.String('--model', {
     description: usageDescriptions['tts.modelVersion'],
     validator: t.isEnum(['1', '2'] as const),
+  });
+
+  requestBody = Option.String('--request-body', {
+    description:
+      'Override the request body with a hardcoded JSON string instead of generating it from options',
   });
 
   async execute() {

--- a/src/tts.test.ts
+++ b/src/tts.test.ts
@@ -758,4 +758,84 @@ describe('instant mode functionality', () => {
       ],
     ]);
   });
+
+  test('omits version field when --last is used without explicit model version', async () => {
+    const lastGeneration = {
+      ids: ['gen_1'],
+      timestamp: Date.now(),
+    };
+
+    const synthesizeJson = mock(() =>
+      Promise.resolve({
+        generations: [
+          {
+            generationId: 'gen_1',
+            audio: 'mock-audio-data',
+          },
+        ],
+      })
+    );
+
+    const { tts } = setupTest({
+      getLastSynthesis: mock(() => Promise.resolve(lastGeneration)),
+      synthesizeJson,
+    });
+
+    await tts.synthesize({
+      text: 'Hello world',
+      last: true,
+      streaming: false,
+    });
+
+    // Verify that the version field is not included in the request
+    expect(synthesizeJson.mock.calls).toEqual([
+      [
+        expect.objectContaining({
+          context: { generationId: 'gen_1' },
+          utterances: [{ text: 'Hello world' }],
+          numGenerations: 1,
+          format: { type: 'wav' },
+        }),
+      ],
+    ]);
+
+    // Ensure version field is not present
+    const requestPayload = synthesizeJson.mock.calls[0][0];
+    expect(requestPayload).not.toHaveProperty('version');
+  });
+
+  test('includes version field when explicit model version is provided', async () => {
+    const synthesizeJson = mock(() =>
+      Promise.resolve({
+        generations: [
+          {
+            generationId: 'gen_1',
+            audio: 'mock-audio-data',
+          },
+        ],
+      })
+    );
+
+    const { tts } = setupTest({
+      synthesizeJson,
+    });
+
+    await tts.synthesize({
+      text: 'Hello world',
+      modelVersion: '2',
+      streaming: false,
+    });
+
+    // Verify that the version field is included in the request
+    expect(synthesizeJson.mock.calls).toEqual([
+      [
+        expect.objectContaining({
+          utterances: [{ text: 'Hello world' }],
+          numGenerations: 1,
+          format: { type: 'wav' },
+          version: '2',
+        }),
+      ],
+    ]);
+  });
 });

--- a/src/tts.ts
+++ b/src/tts.ts
@@ -2,11 +2,19 @@ import { mkdir, writeFile } from 'node:fs/promises';
 import { getLastSynthesisFromHistory, saveLastSynthesisToHistory } from './history';
 import { join, dirname } from 'path';
 import { assert } from 'node:console';
-import { debug, type CommonOpts, getSettings, ApiKeyNotSetError, type Reporter, formatApiKeyForCurl, getApiKeyProvenance } from './common';
+import {
+  debug,
+  type CommonOpts,
+  getSettings,
+  ApiKeyNotSetError,
+  type Reporter,
+  formatApiKeyForCurl,
+  getApiKeyProvenance,
+} from './common';
 import type { ConfigData } from './config';
 import type { Hume, HumeClient } from 'hume';
 import { playAudioFile, withStdinAudioPlayer } from './play_audio';
-import HumeSerialization from 'hume/serialization'
+import HumeSerialization from 'hume/serialization';
 
 type SynthesisOutputOpts =
   | {
@@ -394,7 +402,6 @@ export class Tts {
       );
     }
 
-
     const outputOpts = calculateOutputOpts(opts);
     if (opts.presetVoice) {
       reporter.warn(
@@ -431,13 +438,9 @@ export class Tts {
       // Build TTS object from options as usual
       const baseTts = {
         utterances: [utterance],
+        numGenerations: outputOpts.numGenerations,
         format: { type: opts.format },
       };
-
-      // Only include numGenerations for non-streaming endpoints
-      if (!opts.streaming) {
-        baseTts.numGenerations = outputOpts.numGenerations;
-      }
 
       // Only add version field if modelVersion is explicitly set (not null)
       if (opts.modelVersion !== null) {
@@ -630,20 +633,25 @@ export class Tts {
       throw new ApiKeyNotSetError();
     }
 
-    const baseUrl = opts.baseUrl ?? env.HUME_BASE_URL ?? session.baseUrl ?? globalConfig.baseUrl ?? 'https://api.hume.ai';
+    const baseUrl =
+      opts.baseUrl ??
+      env.HUME_BASE_URL ??
+      session.baseUrl ??
+      globalConfig.baseUrl ??
+      'https://api.hume.ai';
     const apiKey = formatApiKeyForCurl(apiKeyProvenance);
 
     // Determine the endpoint based on streaming mode
     const endpoint = opts.streaming ? '/v0/tts/stream/json' : '/v0/tts';
     const url = `${baseUrl}${endpoint}`;
 
-    const serialized = HumeSerialization.tts.PostedTts.jsonOrThrow(tts)
-    
+    const serialized = HumeSerialization.tts.PostedTts.jsonOrThrow(tts);
+
     // Generate curl command with URL first
     const curlCommand = [
       `curl "${url}"`,
       `  -H "X-Hume-Api-Key: ${apiKey}"`,
-      `  --json '${JSON.stringify(serialized)}'`
+      `  --json '${JSON.stringify(serialized)}'`,
     ].join(' \\\n');
 
     reporter.info('Generated curl command:');

--- a/src/tts.ts
+++ b/src/tts.ts
@@ -96,7 +96,7 @@ const calculateUtterance = (opts: {
 };
 
 export type SynthesisOpts = CommonOpts & {
-  text: string;
+  text?: string;
   voiceName?: string;
   voiceId?: string;
   description?: string;
@@ -117,6 +117,7 @@ export type SynthesisOpts = CommonOpts & {
   streaming?: boolean;
   instantMode?: boolean;
   modelVersion?: '1' | '2';
+  requestBody?: string;
 };
 
 export class Tts {
@@ -150,6 +151,7 @@ export class Tts {
     trailingSilence: null,
     streaming: true,
     instantMode: false,
+    modelVersion: null,
   };
 
   private async writeFiles(
@@ -317,6 +319,8 @@ export class Tts {
     const trailingSilence = osgd('trailingSilence').item;
     const streaming = osgd('streaming').item;
     const instantMode = osgd('instantMode').item;
+    const modelVersion = osgd('modelVersion').item;
+    const requestBody = opts.requestBody ?? null;
 
     // VoiceId and voiceName are mutually exclusive within opts, but
     // not across layers. VoiceId defined with greater priority should
@@ -353,6 +357,8 @@ export class Tts {
       trailingSilence,
       streaming,
       instantMode,
+      modelVersion,
+      requestBody,
     };
   }
 
@@ -375,6 +381,17 @@ export class Tts {
   async synthesize(rawOpts: SynthesisOpts) {
     const { session, globalConfig, env, reporter, hume } = await this.getSettings(rawOpts);
     const opts = Tts.resolveOpts(env, globalConfig, session, rawOpts);
+
+    // Validate that either text or requestBody is provided, but not both
+    if (!opts.text && !opts.requestBody) {
+      throw new Error('Either text parameter or --request-body must be provided');
+    }
+    if (opts.text && opts.requestBody) {
+      throw new Error(
+        'Cannot specify both text parameter and --request-body. Use one or the other.'
+      );
+    }
+
     const outputOpts = calculateOutputOpts(opts);
     if (opts.presetVoice) {
       reporter.warn(
@@ -389,24 +406,50 @@ export class Tts {
 
     const utterance = calculateUtterance({
       ...opts,
-      text,
+      text: text || '',
       speed: opts.speed,
       trailingSilence: opts.trailingSilence,
       provider: opts.provider,
     });
 
-    const tts: Hume.tts.PostedTts = {
-      utterances: [utterance],
-      numGenerations: outputOpts.numGenerations,
-      format: { type: opts.format },
-      version: opts.modelVersion ?? undefined,
-    };
+    let tts: Hume.tts.PostedTts;
 
-    // First add context to support continuation
-    await this.maybeAddContext(opts, tts);
+    // If requestBody is provided, parse it as JSON and use it directly
+    if (opts.requestBody) {
+      try {
+        tts = JSON.parse(String(opts.requestBody));
+        debug('Using hardcoded request body: %O', JSON.stringify(tts, null, 2));
+      } catch (error) {
+        throw new Error(
+          `Invalid JSON in --request-body: ${error instanceof Error ? error.message : 'Unknown error'}`
+        );
+      }
+    } else {
+      // Build TTS object from options as usual
+      debug('modelVersion value: %O', opts.modelVersion);
+      debug('modelVersion !== null: %O', opts.modelVersion !== null);
 
-    // Validate instant_mode requirements
-    if (opts.instantMode) {
+      const baseTts = {
+        utterances: [utterance],
+        numGenerations: outputOpts.numGenerations,
+        format: { type: opts.format },
+      };
+
+      // Only add version field if modelVersion is explicitly set (not null)
+      if (opts.modelVersion !== null) {
+        tts = { ...baseTts, version: opts.modelVersion };
+      } else {
+        tts = baseTts;
+      }
+
+      debug('Final TTS object: %O', JSON.stringify(tts, null, 2));
+
+      // First add context to support continuation
+      await this.maybeAddContext(opts, tts);
+    }
+
+    // Validate instant_mode requirements (only when not using hardcoded request body)
+    if (opts.instantMode && !opts.requestBody) {
       if (!opts.streaming) {
         throw new Error('Instant mode requires streaming to be enabled');
       }

--- a/src/tts.ts
+++ b/src/tts.ts
@@ -2,10 +2,11 @@ import { mkdir, writeFile } from 'node:fs/promises';
 import { getLastSynthesisFromHistory, saveLastSynthesisToHistory } from './history';
 import { join, dirname } from 'path';
 import { assert } from 'node:console';
-import { debug, type CommonOpts, getSettings, ApiKeyNotSetError, type Reporter } from './common';
+import { debug, type CommonOpts, getSettings, ApiKeyNotSetError, type Reporter, formatApiKeyForCurl, getApiKeyProvenance } from './common';
 import type { ConfigData } from './config';
 import type { Hume, HumeClient } from 'hume';
 import { playAudioFile, withStdinAudioPlayer } from './play_audio';
+import HumeSerialization from 'hume/serialization'
 
 type SynthesisOutputOpts =
   | {
@@ -118,6 +119,7 @@ export type SynthesisOpts = CommonOpts & {
   instantMode?: boolean;
   modelVersion?: '1' | '2';
   requestJson?: string;
+  curl?: boolean;
 };
 
 export class Tts {
@@ -392,6 +394,7 @@ export class Tts {
       );
     }
 
+
     const outputOpts = calculateOutputOpts(opts);
     if (opts.presetVoice) {
       reporter.warn(
@@ -428,9 +431,13 @@ export class Tts {
       // Build TTS object from options as usual
       const baseTts = {
         utterances: [utterance],
-        numGenerations: outputOpts.numGenerations,
         format: { type: opts.format },
       };
+
+      // Only include numGenerations for non-streaming endpoints
+      if (!opts.streaming) {
+        baseTts.numGenerations = outputOpts.numGenerations;
+      }
 
       // Only add version field if modelVersion is explicitly set (not null)
       if (opts.modelVersion !== null) {
@@ -461,6 +468,11 @@ export class Tts {
 
     if (!hume) {
       throw new ApiKeyNotSetError();
+    }
+
+    // Handle curl generation
+    if (opts.curl) {
+      return this.generateCurlCommand(opts, env, globalConfig, session, reporter, tts);
     }
 
     if (opts.streaming) {
@@ -603,5 +615,38 @@ export class Tts {
     reporter.json({ result, written_files: writtenFiles });
 
     await this.playAudios(opts.play, writtenFiles, reporter, opts.playCommand ?? null);
+  }
+
+  private async generateCurlCommand(
+    opts: ReturnType<typeof Tts.resolveOpts>,
+    env: typeof process.env,
+    globalConfig: ConfigData,
+    session: ConfigData,
+    reporter: Reporter,
+    tts: Hume.tts.PostedTts
+  ) {
+    const apiKeyProvenance = getApiKeyProvenance(opts, globalConfig, session, env);
+    if (!apiKeyProvenance) {
+      throw new ApiKeyNotSetError();
+    }
+
+    const baseUrl = opts.baseUrl ?? env.HUME_BASE_URL ?? session.baseUrl ?? globalConfig.baseUrl ?? 'https://api.hume.ai';
+    const apiKey = formatApiKeyForCurl(apiKeyProvenance);
+
+    // Determine the endpoint based on streaming mode
+    const endpoint = opts.streaming ? '/v0/tts/stream/json' : '/v0/tts';
+    const url = `${baseUrl}${endpoint}`;
+
+    const serialized = HumeSerialization.tts.PostedTts.jsonOrThrow(tts)
+    
+    // Generate curl command with URL first
+    const curlCommand = [
+      `curl "${url}"`,
+      `  -H "X-Hume-Api-Key: ${apiKey}"`,
+      `  --json '${JSON.stringify(serialized)}'`
+    ].join(' \\\n');
+
+    reporter.info('Generated curl command:');
+    console.log(curlCommand);
   }
 }

--- a/src/tts.ts
+++ b/src/tts.ts
@@ -117,7 +117,7 @@ export type SynthesisOpts = CommonOpts & {
   streaming?: boolean;
   instantMode?: boolean;
   modelVersion?: '1' | '2';
-  requestBody?: string;
+  requestJson?: string;
 };
 
 export class Tts {
@@ -320,7 +320,7 @@ export class Tts {
     const streaming = osgd('streaming').item;
     const instantMode = osgd('instantMode').item;
     const modelVersion = osgd('modelVersion').item;
-    const requestBody = opts.requestBody ?? null;
+    const requestJson = opts.requestJson ?? null;
 
     // VoiceId and voiceName are mutually exclusive within opts, but
     // not across layers. VoiceId defined with greater priority should
@@ -358,7 +358,7 @@ export class Tts {
       streaming,
       instantMode,
       modelVersion,
-      requestBody,
+      requestJson,
     };
   }
 
@@ -382,13 +382,13 @@ export class Tts {
     const { session, globalConfig, env, reporter, hume } = await this.getSettings(rawOpts);
     const opts = Tts.resolveOpts(env, globalConfig, session, rawOpts);
 
-    // Validate that either text or requestBody is provided, but not both
-    if (!opts.text && !opts.requestBody) {
-      throw new Error('Either text parameter or --request-body must be provided');
+    // Validate that either text or requestJson is provided, but not both
+    if (!opts.text && !opts.requestJson) {
+      throw new Error('Either text parameter or --request-json must be provided');
     }
-    if (opts.text && opts.requestBody) {
+    if (opts.text && opts.requestJson) {
       throw new Error(
-        'Cannot specify both text parameter and --request-body. Use one or the other.'
+        'Cannot specify both text parameter and --request-json. Use one or the other.'
       );
     }
 
@@ -414,21 +414,18 @@ export class Tts {
 
     let tts: Hume.tts.PostedTts;
 
-    // If requestBody is provided, parse it as JSON and use it directly
-    if (opts.requestBody) {
+    // If requestJson is provided, parse it as JSON and use it directly
+    if (opts.requestJson) {
       try {
-        tts = JSON.parse(String(opts.requestBody));
+        tts = JSON.parse(String(opts.requestJson));
         debug('Using hardcoded request body: %O', JSON.stringify(tts, null, 2));
       } catch (error) {
         throw new Error(
-          `Invalid JSON in --request-body: ${error instanceof Error ? error.message : 'Unknown error'}`
+          `Invalid JSON in --request-json: ${error instanceof Error ? error.message : 'Unknown error'}`
         );
       }
     } else {
       // Build TTS object from options as usual
-      debug('modelVersion value: %O', opts.modelVersion);
-      debug('modelVersion !== null: %O', opts.modelVersion !== null);
-
       const baseTts = {
         utterances: [utterance],
         numGenerations: outputOpts.numGenerations,
@@ -442,14 +439,12 @@ export class Tts {
         tts = baseTts;
       }
 
-      debug('Final TTS object: %O', JSON.stringify(tts, null, 2));
-
       // First add context to support continuation
       await this.maybeAddContext(opts, tts);
     }
 
     // Validate instant_mode requirements (only when not using hardcoded request body)
-    if (opts.instantMode && !opts.requestBody) {
+    if (opts.instantMode && !opts.requestJson) {
       if (!opts.streaming) {
         throw new Error('Instant mode requires streaming to be enabled');
       }


### PR DESCRIPTION
Two changes

1. Fixes a bug where `version` was being supplied as `null` sometimes which is not actually accepted by the API.
2. Adds a `--request-json` flag that allows you to hardcode a json body to get sent. This is useful if you want to use multi-utterances or anything that the CLI doesn't fully support. You still get the audio played back, and you still get context parsed e.g. you can use `--last` in the next request if you want to use continuation.
3. Adds a `--curl` flag where you can use the CLI to construct a `curl` command that you can use by itself.